### PR TITLE
新增場次後台crud

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,7 +298,11 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+<<<<<<< HEAD
   x86_64-linux
+=======
+  arm64-darwin-22
+>>>>>>> 120a87f (add showtime crud)
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)

--- a/app/assets/stylesheets/admin/showtimes.css
+++ b/app/assets/stylesheets/admin/showtimes.css
@@ -1,0 +1,4 @@
+/*
+  Place all the styles related to the matching controller here.
+  They will automatically be included in application.css.
+*/

--- a/app/controllers/admin/showtimes_controller.rb
+++ b/app/controllers/admin/showtimes_controller.rb
@@ -1,0 +1,100 @@
+module Admin
+  class ShowtimesController < ApplicationController
+    before_action :authenticate_user!
+    before_action :find_movie, only: %i[index new create destroy update]
+    before_action :find_showtime, only: %i[destroy edit update]
+
+    def index
+      @showtimes = @movie.showtimes.all
+      @movies = Movie.all
+    end
+
+    def new
+      @showtime = @movie.showtimes.new
+    end
+
+    def create
+      @showtime = @movie.showtimes.new(showtime_params)
+      @showtimes = @movie.showtimes.all
+
+      showtime_start = showtime_params[:started_at].to_datetime.to_i
+      showtime_end = showtime_params[:end_at].to_datetime.to_i
+
+      showtime_all = @showtimes.map {|data| [data.started_at.to_i, data.end_at.to_i]}
+      current_time = Time.current.to_i 
+
+      showtime_condition = showtime_all.map do |arr| 
+        if showtime_start < arr[0] || showtime_start > arr[1]
+          if showtime_start < arr[0]
+            showtime_end < arr[0]
+          else
+            showtime_end > arr[1]
+          end
+        else
+          false
+        end
+      end
+      if showtime_condition.include?(false) ||    
+         showtime_start > showtime_end ||      
+         showtime_start < current_time || 
+         showtime_start == showtime_end 
+        redirect_to admin_movie_showtimes_path, notice: "場次設定有誤,請重新輸入"
+      else
+        @showtime.save
+        redirect_to admin_movie_showtimes_path, notice: "場次新增成功"
+      end
+    end
+
+    def edit; end
+
+    def update
+      @showtimes = @movie.showtimes.all
+
+      showtime_start = showtime_params[:started_at].to_datetime.to_i
+      showtime_end = showtime_params[:end_at].to_datetime.to_i
+
+      showtime_all = @showtimes.map {|data| [data.started_at.to_i, data.end_at.to_i]}
+      current_time = DateTime.now.to_i
+      
+      showtime_condition = showtime_all.map do |arr| 
+        if showtime_start < arr[0] || showtime_start > arr[1]
+          if showtime_start < arr[0]
+            showtime_end < arr[0]
+          else
+            showtime_end > arr[1]
+          end
+        else
+          false
+        end
+      end
+      if showtime_condition.include?(false) || 
+         showtime_start > showtime_end ||      
+         showtime_start < current_time || 
+         showtime_start == showtime_end 
+        redirect_to admin_movie_showtimes_path, notice: "場次更新設定有誤,請重新輸入"
+      else
+        @showtime.update(showtime_params)
+        redirect_to admin_movie_showtimes_path, notice: "場次更新成功"
+      end
+    end
+
+    def destroy
+      @showtime.destroy
+      redirect_to admin_movie_showtimes_path, notice: "刪除場次成功"
+    end
+
+    private
+    def find_movie
+      @movie = Movie.find(params[:movie_id])
+    end
+
+    def find_showtime
+      @showtime = Showtime.find(params[:id])
+    end
+
+    def showtime_params
+      params.require(:showtime).permit(:started_at, :end_at, :deleted_at)
+    end
+
+  end
+end

--- a/app/helpers/admin/showtimes_helper.rb
+++ b/app/helpers/admin/showtimes_helper.rb
@@ -1,0 +1,2 @@
+module Admin::ShowtimesHelper
+end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 
 class Movie < ApplicationRecord
+  #validates
   validates :name, presence: true
   validates :description, presence: true
+  
+  #relationship
   belongs_to :user
+
   has_one_attached :movie_poster
   has_many_attached :scene_images
+  has_many :showtimes
 
   enum film_rating: { general: 0, parental_guidance: 1, parental_guidance12: 2, parental_guidance15: 3, restricted: 4 }
 end

--- a/app/models/showtime.rb
+++ b/app/models/showtime.rb
@@ -1,0 +1,7 @@
+class Showtime < ApplicationRecord
+  acts_as_paranoid
+
+  #relationship
+  belongs_to :movie
+  
+end

--- a/app/views/admin/movies/_sidebar.html.erb
+++ b/app/views/admin/movies/_sidebar.html.erb
@@ -1,0 +1,15 @@
+<div class="sidebar p-1 bg-slategray">
+  <div class="position-sticky">
+    <h3>系統首頁</h3>
+    <ul class="list-group list-group-flush ">
+      <li class="list-group-item m-0 p-0 bg-slategray"><%= link_to "電影管理",admin_movies_path ,
+          class:"p-3 my-1 d-block text-center"%></li>
+      <li class="list-group-item m-0 p-0 bg-slategray"><%= link_to "場次管理", admin_movies_path,
+          class:"p-3 my-1 d-block text-center"%></li>
+      <li class="list-group-item m-0 p-0 bg-slategray"><%= link_to "影聽管理",admin_theaters_path ,
+          class:"p-3 my-1 d-block text-center"%></li>
+      <li class="list-group-item m-0 p-0 bg-slategray"><%= link_to "消息管理",admin_news_index_path ,
+          class:"p-3 my-1 d-block text-center"%></li>
+    </ul>
+  </div>
+</div>

--- a/app/views/admin/movies/index.html.erb
+++ b/app/views/admin/movies/index.html.erb
@@ -29,6 +29,8 @@
               <tr>
                 <th scope="row"><%= link_to movie.name,edit_admin_movie_path(movie) %></th>
                 <td>1</td>
+                <th scope="row"><%= link_to movie.name,admin_movie_path(movie) %></th>
+                <td><%= link_to "查看",admin_movie_showtimes_path(movie) %></td>
                 <td><%= movie.debut_date %></td>
                 <td>123</td>
                 <td><%= movie.user_id %></td>

--- a/app/views/admin/showtimes/edit.html.erb
+++ b/app/views/admin/showtimes/edit.html.erb
@@ -1,0 +1,18 @@
+<%= flash[:notice] %>
+<h1>編輯場次</h1>
+
+<%= form_with(model: @showtime, url: admin_movie_showtimes_path, method: "post") do |form| %>
+  <div>
+    <%= form.label :"開始時間" %>
+    <input type="datetime-local" name="showtime[started_at]" min="<%= Time.now.strftime("%Y-%m-%dT%H:%M") %>">
+    <br>
+  </div>
+  <div>
+    <%= form.label :"結束時間" %>
+    <input type="datetime-local" name="showtime[end_at]">
+    <br>
+  </div>
+  <%= form.submit "送出" %>
+
+<% end %>
+

--- a/app/views/admin/showtimes/index.html.erb
+++ b/app/views/admin/showtimes/index.html.erb
@@ -1,0 +1,18 @@
+<h1>管理場次</h1>
+
+<ul> 
+  <% @showtimes.each do |showtime| %>
+  <li>
+    <%= showtime.started_at %>
+    <%= showtime.end_at %>
+    <%= link_to "刪除", admin_movie_showtime_path(showtime.movie, showtime), method: "delete", data: {confirm: "確定要刪除場次嗎？"} %>
+     <%= link_to "編輯", edit_admin_movie_showtime_path(showtime.movie, showtime) %>
+  </li>
+  <% end %>
+</ul>
+
+<%= link_to "新增場次", new_admin_movie_showtime_path %>
+<br>
+<br>
+<%= link_to "返回系統首頁", admin_movies_path %>
+

--- a/app/views/admin/showtimes/new.html.erb
+++ b/app/views/admin/showtimes/new.html.erb
@@ -1,0 +1,18 @@
+<%= flash[:notice] %>
+<h1>新增場次</h1>
+
+<%= form_with(model: @showtime, url: admin_movie_showtimes_path, method: "post") do |form| %>
+  <div>
+    <%= form.label :"開始時間" %>
+    <input type="datetime-local" name="showtime[started_at]" min="<%= Time.now.strftime("%Y-%m-%dT%H:%M") %>">
+    <br>
+  </div>
+  <div>
+    <%= form.label :"結束時間" %>
+    <input type="datetime-local" name="showtime[end_at]">
+    <br>
+  </div>
+  <%= form.submit "送出" %>
+
+<% end %>
+

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,7 @@ module RubyCinema
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    config.time_zone = 'Taipei'
+    # config.time_zone = 'Taipei'
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :users, only: %i[index edit update delete]
     resources :movies do
+<<<<<<< HEAD
       member do
         delete :delete_images
         post :create_movie_poster
@@ -27,6 +28,11 @@ Rails.application.routes.draw do
     end
     resources :showtimes
     resources :news
+=======
+      resources :showtimes
+    end
+      resources :news
+>>>>>>> 120a87f (add showtime crud)
     resources :theaters
     resources :cinemas do
       resources :seats, only: %i[index new create]

--- a/db/migrate/20221210054412_create_showtimes.rb
+++ b/db/migrate/20221210054412_create_showtimes.rb
@@ -1,0 +1,14 @@
+class CreateShowtimes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :showtimes do |t|
+      t.datetime :started_at
+      t.datetime :end_at
+      t.datetime :deleted_at
+      t.integer :movie_id
+      t.integer :cinema_id
+
+      t.timestamps
+    end
+    add_index :showtimes, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+<<<<<<< HEAD
 ActiveRecord::Schema.define(version: 2022_12_09_043248) do
+=======
+ActiveRecord::Schema.define(version: 2022_12_10_054412) do
+>>>>>>> 120a87f (add showtime crud)
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +45,7 @@ ActiveRecord::Schema.define(version: 2022_12_09_043248) do
     t.index ["user_id"], name: "index_movies_on_user_id"
   end
 
+<<<<<<< HEAD
   create_table "orders", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.decimal "amount"
@@ -77,6 +82,17 @@ ActiveRecord::Schema.define(version: 2022_12_09_043248) do
     t.text "seat_list", default: [], array: true
     t.string "category", default: "added"
     t.index ["cinema_id"], name: "index_seats_on_cinema_id"
+=======
+  create_table "showtimes", force: :cascade do |t|
+    t.datetime "started_at"
+    t.datetime "end_at"
+    t.datetime "deleted_at"
+    t.integer "movie_id"
+    t.integer "cinema_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["deleted_at"], name: "index_showtimes_on_deleted_at"
+>>>>>>> 120a87f (add showtime crud)
   end
 
   create_table "theaters", force: :cascade do |t|
@@ -109,9 +125,12 @@ ActiveRecord::Schema.define(version: 2022_12_09_043248) do
     t.datetime "locked_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "fb_uid"
+    t.string "fb_token"
     t.string "name"
     t.datetime "deleted_at"
     t.integer "role", default: 0
+<<<<<<< HEAD
     t.string "fb_uid"
     t.string "fb_token"
     t.string "name"
@@ -119,6 +138,8 @@ ActiveRecord::Schema.define(version: 2022_12_09_043248) do
     t.integer "role", default: 0
     t.string "google_uid"
     t.string "google_token"
+=======
+>>>>>>> 120a87f (add showtime crud)
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/test/controllers/admin/showtimes_controller_test.rb
+++ b/test/controllers/admin/showtimes_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Admin::ShowtimesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/showtimes.yml
+++ b/test/fixtures/showtimes.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  started_at: 2022-12-10 13:44:12
+  end_at: 2022-12-10 13:44:12
+  deleted_at: 2022-12-10 13:44:12
+  movie_id: 1
+  cinema_id: 1
+
+two:
+  started_at: 2022-12-10 13:44:12
+  end_at: 2022-12-10 13:44:12
+  deleted_at: 2022-12-10 13:44:12
+  movie_id: 1
+  cinema_id: 1

--- a/test/models/showtime_test.rb
+++ b/test/models/showtime_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ShowtimeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
<img width="1434" alt="截圖 2022-12-13 上午1 03 44" src="https://user-images.githubusercontent.com/115055771/207256816-a13df513-0e36-4566-a56b-8ebbf0ebf928.png">
-------後台首頁修改為場次管理，內容按查看即可

<img width="797" alt="截圖 2022-12-13 上午1 05 27" src="https://user-images.githubusercontent.com/115055771/207256984-0daeb359-6cf8-4f1b-8cc2-559de568a17a.png">
點進查看會進入到該電影的場次表，可透過新增增加影城、編輯及刪除。

<img width="580" alt="截圖 2022-12-13 上午1 05 45" src="https://user-images.githubusercontent.com/115055771/207257172-adab585c-b7b8-4622-80bf-583893b47caf.png">
新增場次

<img width="606" alt="截圖 2022-12-13 上午1 05 58" src="https://user-images.githubusercontent.com/115055771/207257225-c590574c-eeb5-4f77-bc1b-4f24c5ecf09a.png">
選取時，過去的時間會直接反灰，如小時或分鐘選到，會直接被阻擋下來。
