### PR TITLE
Issue90 使用者資料相關介面切版

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,17 +5,18 @@
 
 //user
 @import "bootstrap";
-@import "nav";
-@import "users";
+@import "nav.scss";
+@import "users.scss";
 @import "root.scss";
 @import "theater.scss";
-@import "orders";
+@import "orders.scss";
 @import "ticketing/select_seats.scss";
 @import "ticketing/select_tickets.scss";
 @import "actiontext.scss";
 @import "news.scss";
 @import "login.scss";
 @import "movie/index.scss";
+@import "find_showtimes.scss";
 
 button {
   all: unset;
@@ -27,9 +28,4 @@ ul {
 
 a {
   text-decoration: none;
-}
-
-.search-bottom {
-  background-color: #365FA4;
-  color: white;
 }

--- a/app/assets/stylesheets/find_showtimes.scss
+++ b/app/assets/stylesheets/find_showtimes.scss
@@ -1,0 +1,4 @@
+.search-bottom {
+  background-color: #365fa4;
+  color: white;
+}

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -7,7 +7,9 @@ module Admin
     before_action :current_user_is_admin
 
     def index
-      @users = User.all
+      @customers = User.user
+      @staffs = User.staff
+      @admins = User.admin
     end
 
     def edit; end

--- a/app/views/admin/showtimes/index.html.erb
+++ b/app/views/admin/showtimes/index.html.erb
@@ -1,31 +1,35 @@
-<div class="main flex-grow-1 p-0 ms-1 text-dark">
-  <div class="container container-breadcrumb">
-    <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
-      <ol class="breadcrumb">
-        <li class="breadcrumb-item"><%= link_to "後台首頁", admin_movies_path %></li>
-        <li class="breadcrumb-item"><%= @movie.name %></li>
-        <li class="breadcrumb-item active" aria-current="page">場次列表</li>
-      </ol>
-    </nav>
-  </div>
-  <div class="container">
-    <h2 class="text-dark fs-6">片長：<%= @movie.duration %>分鐘</h2>
-    <%= render "new" %>
-    <table class="table table-striped my-3">
-      <thead>
-        <tr>
-          <th scope="col" class=" text-bg-slategray">影城</th>
-          <th scope="col" class=" text-bg-slategray">影廳</th>
-          <th scope="col" class=" text-bg-slategray">開始時間</th>
-          <th scope="col" class=" text-bg-slategray">結束時間</th>
-          <th scope="col" class=" text-bg-slategray">刪除</th>
-        </tr>
-      </thead>
-      <tbody class="showtimes">
-        <%= render @showtimes %>
-      </tbody>
-    </table>
-    <%= will_paginate @showtimes, class:"text-center" %>
+<div class="continer vh-100">
+  <div class="d-flex">
+    <div class="main flex-grow-1 p-0 ms-1 text-dark">
+      <div class="container container-breadcrumb">
+        <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
+          <ol class="breadcrumb">
+            <li class="breadcrumb-item"><%= link_to "後台首頁", admin_movies_path %></li>
+            <li class="breadcrumb-item"><%= @movie.name %></li>
+            <li class="breadcrumb-item active" aria-current="page">場次列表</li>
+          </ol>
+        </nav>
+      </div>
+      <div class="container">
+        <h2 class="text-dark fs-6">片長：<%= @movie.duration %>分鐘</h2>
+        <%= render "new" %>
+        <table class="table table-striped my-3">
+          <thead class=" text-bg-slategray">
+            <tr>
+              <th scope="col">影城</th>
+              <th scope="col">影廳</th>
+              <th scope="col">開始時間</th>
+              <th scope="col">結束時間</th>
+              <th scope="col">刪除</th>
+            </tr>
+          </thead>
+          <tbody class="showtimes">
+            <%= render @showtimes %>
+          </tbody>
+        </table>
+        <%= will_paginate @showtimes, class:"text-center" %>
+      </div>
+    </div>
   </div>
 </div>
 </div>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,24 +1,26 @@
-<table>
-  <ul>
-    <tr>
-      <td>序號</td>
-      <td>操作</td>
-      <td></td>
-      <td>身份</td>
-      <td>使用者姓名</td>
-    </tr>
+<div class="container my-3">
+  <table class="table table-striped">
+    <thead class=" text-bg-slategray">
+      <tr>
+        <th scope="col" class="col-1">序號</th>
+        <th scope="col" class="col-1">操作</th>
+        <th scope="col" class="col-1"></th>
+        <th scope="col" class="col-2">身份</th>
+        <th scope="col" class="col-3">使用者姓名</th>
+        <th scope="col" class="col-4">信箱</th>
+      </tr>
+    </thead>
     <% users.each do |user| %>
-    <tr>
-      <td> <%= user.id %></td>
-      <td> <%= link_to "編輯" , edit_admin_user_path(user) %></td>
-      <td> <%= link_to "刪除" , user_registration_path(user),method:"delete",data:{confirm:"確定刪除？"} %></td>
-      <td> <%= user.role %></td>
-      <td> <%= user.name %></td>
-      <td> <%= user.email %></td>
-
-    </tr>
+      <tbody>
+        <tr>
+          <td> <%= user.id %></td>
+          <td> <%= link_to "編輯" , edit_admin_user_path(user) %></td>
+          <td> <%= link_to "刪除" , user_registration_path(user),method:"delete",data:{confirm:"確定刪除？"} %></td>
+          <td> <%= user.role %></td>
+          <td> <%= user.name %></td>
+          <td> <%= user.email %></td>
+        </tr>
+      </tbody>
     <% end %>
-
-  </ul>
-
-</table>
+  </table>
+</div>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,16 +1,38 @@
-<h1>變更使用者資料</h1>
-<%= form_with(model: @user, url: admin_user_path, method:"patch") do |form| %>
-  <div>
-    <%= form.label :name %>
-    <%= form.text_field :name %>
+<div class="container w-50 py-5 text-center">
+  <h2 class="text-center py-5">修改會員資料</h2>
+  <section class="w-75 mx-auto">
+    <%= form_with(model: @user, url: admin_user_path, method:"patch") do |f| %>
+      <!-- name -->
+      <div class="my-3">
+        <div>
+          <label class="form-label" for="form1Example13">您的姓名</label>
+          <div>
+            <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control text-center" %>
+          </div>
+        </div>
+        <!-- email -->
+        <div class="my-3">
+          <div>
+            <label class="form-label" for="form1Example13">網路帳號信箱</label>
+          </div>
+          <div>
+            <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control text-center" %>
+          </div>
+        </div>
+        <div class="my-3">
+          <div>
+            <label class="form-label" for="form1Example13">使用者身份</label>
+          </div>
+          <div>
+            <%= f.select :role, options_for_select(User.roles.keys, @user.role), {}, class: "form-select text-center" %>
+          </div>
+        </div>
+        <div class="actions mb-5">
+          <%= f.submit("修改", class: "btn btn-md btn-outline-primary") %>
+        </div>
+      <% end %>
+    </section>
+    <div class="d-flex justify-content-center">
+      <%= link_to "回列表", admin_users_path, class: "btn btn-lg search-bottom"%>
+    </div>
   </div>
-  <div>
-    <%= form.label :email %>
-    <%= form.text_field :email %>
-  </div>
-  <div>
-    <%= form.label :role %>
-    <%= form.select :role, options_for_select(User.roles.keys, @user.role) %>
-  </div>
-  <%= form.submit %>
-<% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,31 +1,20 @@
+  
 <div class="container w-50 py-5 text-center">
   <h2 class="text-center py-5">修改會員資料</h2>
   <section class="w-75 mx-auto">
     <%= form_with(model: @user, url: admin_user_path, method:"patch") do |f| %>
-      <!-- name -->
       <div class="my-3">
         <div>
-          <label class="form-label" for="form1Example13">您的姓名</label>
-          <div>
-            <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control text-center" %>
-          </div>
-        </div>
-        <!-- email -->
-        <div class="my-3">
-          <div>
-            <label class="form-label" for="form1Example13">網路帳號信箱</label>
-          </div>
-          <div>
-            <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control text-center" %>
-          </div>
+          <%= f.label :name, "您的姓名", class: "form-label" %>
+          <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control text-center" %>
         </div>
         <div class="my-3">
-          <div>
-            <label class="form-label" for="form1Example13">使用者身份</label>
-          </div>
-          <div>
-            <%= f.select :role, options_for_select(User.roles.keys, @user.role), {}, class: "form-select text-center" %>
-          </div>
+          <%= f.label :email, class: "form-label" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control text-center" %>
+        </div>
+        <div class="my-3">
+          <%= f.label :role, "使用者身份", class: "form-label" %>
+          <%= f.select :role, options_for_select(User.roles.keys, @user.role), {}, class: "form-select text-center" %>
         </div>
         <div class="actions mb-5">
           <%= f.submit("修改", class: "btn btn-md btn-outline-primary") %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,10 +1,30 @@
-<h1>使用者管理介面</h1>
-<div>
-<%= link_to "回首頁", root_path %>
-<p>--------------user-----------------</p>
-<%= render "form", users: User.user %>
-<p>--------------staff-----------------</p>
-<%= render "form", users: User.staff %>
-<p>--------------admin-----------------</p>
-<%= render "form", users: User.admin %>
+<div class="continer vh-100  text-white w-75 mx-auto">
+  <div class="d-flex">
+    <div class="main flex-grow-1 p-0 ms-1">
+      <div class="container container-breadcrumb ">
+        <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
+          <ol class="breadcrumb">
+            <li class="breadcrumb-item"><%= link_to "後台首頁",admin_movies_path %></li>
+            <li class="breadcrumb-item active" aria-current="page">
+              <h2 class="text-nowrap">使用者管理介面</h2>
+            </li>
+          </ol>
+        </nav>
+      </div>
+      <div class="text-dark">
+        <section>
+          <h3 class="text-center">管理員</h3>
+          <%= render "form", users: @admins %>
+        </section>
+        <section>
+          <h3 class="text-center">員工</h3>
+          <%= render "form", users: @staffs %>
+        </section>
+        <section>
+          <h3 class="text-center">顧客</h3>
+          <%= render "form", users: @customers %>
+        </section>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,65 +1,42 @@
 <div class="container w-50 py-5 text-center">
-  <h2 class="text-center py-5">修改會員資料</h2>
+  <h2 class="text-center">修改會員資料</h2>
   <section class="w-75 mx-auto border-bottom border-primary border-">
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-      <!-- name -->
       <div class="my-3">
-        <div>
-          <label class="form-label" for="form1Example13">您的姓名</label>
-          <div>
-            <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control text-center" %>
-          </div>
-        </div>
-        <!-- email -->
+        <%= f.label :name, "您的姓名", class: "form-label" %>
+        <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control text-center" %>
         <div class="my-3">
-          <div>
-            <label class="form-label" for="form1Example13">網路帳號信箱</label>
-          </div>
-          <div>
-            <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control text-center" %>
-          </div>
+          <%= f.label :email, class: "form-label" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control text-center" %>
         </div>
         <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
           <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
         <% end %>
-        <!-- password  -->
         <div class="my-3">
           <div>
-            <label class="form-label" for="form1Example13">新密碼</label>
-          </div>
-          <div>
+            <%= f.label :password, "新密碼", class: "form-label" %>
             <%= f.password_field :password, autocomplete: "new-password", class: "form-control text-center", placeholder: "至少要有#{@minimum_password_length}個字元，不更改密碼則不需填寫" %>
           </div>
-        </div>
-        <!-- password_confirmation  -->
-        <div class="my-3">
-          <div>
+          <div class="my-3">
             <label class="form-label" for="form1Example13">確認新密碼</label>
-          </div>
-          <div>
+            <%= f.label :password_confirmation, "確認新密碼", class: "form-label" %>
             <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control text-center" %>
           </div>
-        </div>
-        <!-- current_password -->
-        <div class="my-3">
-          <div>
-            <label class="form-label" for="form1Example13">輸入原密碼以儲存變更</label>
-          </div>
-          <div>
+          <div class="my-3">
+            <%= f.label :current_password, "輸入原密碼以儲存變更", class: "form-label" %>
             <%= f.password_field :current_password, autocomplete: "current-password", class: "form-control text-center" %>
           </div>
-        </div>
-        <div class="actions mb-5">
-          <%= f.submit("修改", class: "btn btn-md btn-outline-primary") %>
-        </div>
-      <% end %>
-    </section>
-    <section class="py-5">
-      <h3>刪除帳號</h3>
-      <p>不再使用本帳號? 
-        <%= button_to "刪除帳號", registration_path(resource_name), data: { confirm: "確定刪除帳號?" }, method: :delete, class: "btn btn-md btn-outline-danger" %></p>
-    </section>
-    <div class="d-flex justify-content-center">
-      <%= link_to "回首頁", root_path, class: "btn btn-lg search-bottom"%>
+          <div class="actions mb-5">
+            <%= f.submit("修改", class: "btn btn-md btn-outline-primary px-4") %>
+          </div>
+        <% end %>
+      </section>
+      <section class="py-5">
+        <h3>刪除帳號</h3>
+        <p>不再使用本帳號? 
+          <%= button_to "刪除帳號", registration_path(resource_name), data: { confirm: "確定刪除帳號?" }, method: :delete, class: "btn btn-md btn-outline-danger" %></p>
+      </section>
+      <div class="d-flex justify-content-center">
+        <%= link_to "回首頁", root_path, class: "btn btn-lg search-bottom"%>
+      </div>
     </div>
-  </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,71 +1,65 @@
-<h2>修改會員資料</h2>
-
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  
-    <!-- name -->
-    <div class="mb-4">
-      <div>
-        <label class="form-label" for="form1Example13">您的姓名</label>
-      </div>
-      <div>
-        <%= f.text_field :name, autofocus: true, autocomplete: "name" %> 
-      </div>
-    </div>  
-
-      <!-- email -->
-    <div class="field mb-4">
-      <div>
-        <label class="form-label" for="form1Example13">網路帳號信箱</label>
-      </div>
-      <div>
-        <%= f.email_field :email, autofocus: true, autocomplete: "email" %> 
-      </div>
+<div class="container w-50 py-5 text-center">
+  <h2 class="text-center py-5">修改會員資料</h2>
+  <section class="w-75 mx-auto border-bottom border-primary border-2">
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+      <!-- name -->
+      <div class="my-3">
+        <div>
+          <label class="form-label" for="form1Example13">您的姓名</label>
+          <div>
+            <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control text-center" %>
+          </div>
+        </div>
+        <!-- email -->
+        <div class="my-3">
+          <div>
+            <label class="form-label" for="form1Example13">網路帳號信箱</label>
+          </div>
+          <div>
+            <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control text-center" %>
+          </div>
+        </div>
+        <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+          <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+        <% end %>
+        <!-- password  -->
+        <div class="my-3">
+          <div>
+            <label class="form-label" for="form1Example13">新密碼</label>
+          </div>
+          <div>
+            <%= f.password_field :password, autocomplete: "new-password", class: "form-control text-center", placeholder: "至少要有#{@minimum_password_length}個字元，不更改密碼則不需填寫" %>
+          </div>
+        </div>
+        <!-- password_confirmation  -->
+        <div class="my-3">
+          <div>
+            <label class="form-label" for="form1Example13">確認新密碼</label>
+          </div>
+          <div>
+            <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control text-center" %>
+          </div>
+        </div>
+        <!-- current_password -->
+        <div class="my-3">
+          <div>
+            <label class="form-label" for="form1Example13">輸入原密碼以儲存變更</label>
+          </div>
+          <div>
+            <%= f.password_field :current_password, autocomplete: "current-password", class: "form-control text-center" %>
+          </div>
+        </div>
+        <div class="actions mb-5">
+          <%= f.submit("修改", class: "btn btn-md btn-outline-primary") %>
+        </div>
+      <% end %>
+    </section>
+    <section class="py-5">
+      <h3>刪除帳號</h3>
+      <p>不再使用本帳號? 
+        <%= button_to "刪除帳號", registration_path(resource_name), data: { confirm: "確定刪除帳號?" }, method: :delete, class: "btn btn-md btn-outline-danger" %></p>
+    </section>
+    <div class="d-flex justify-content-center">
+      <%= link_to "回首頁", root_path, class: "btn btn-lg search-bottom"%>
     </div>
-
-    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-      <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-    <% end %>
-
-    <!-- password  -->
-    <div class="field mb-4">
-      <div>
-        <label class="form-label" for="form1Example13">新密碼（不更改密碼則不需填寫）</label>
-        <% if @minimum_password_length %>
-        <em>(至少要有 <%= @minimum_password_length %> 個字元)</em>
-        <% end %><br />
-      </div>
-      <div>
-        <%= f.password_field :password, autocomplete: "new-password" %>                  
-      </div>
-    </div>
-    
-    <!-- password_confirmation  -->
-    <div class="field mb-4">
-      <div>
-        <label class="form-label" for="form1Example13">確認新密碼</label>
-      </div>
-      <div>
-        <%= f.password_field :password_confirmation, autocomplete: "new-password" %>                  
-      </div>
-    </div>
-
-    <!-- current_password -->
-    <div class="field mb-4">
-      <div>
-        <label class="form-label" for="form1Example13">輸入原密碼以儲存變更</label>
-      </div>
-      <div>
-        <%= f.password_field :current_password, autocomplete: "current-password" %>
-      </div>
-    </div>
-
-    <div class="actions">
-      <%= f.submit "修改" %>
-    </div>
-  <% end %>
-
-<h3>刪除帳號</h3>
-
-<p>不再使用本帳號? <%= button_to "刪除帳號", registration_path(resource_name), data: { confirm: "確定刪除帳號?" }, method: :delete %></p>
-
-<%= link_to "上一頁", :back %>
+  </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="container w-50 py-5 text-center">
   <h2 class="text-center py-5">修改會員資料</h2>
-  <section class="w-75 mx-auto border-bottom border-primary border-2">
+  <section class="w-75 mx-auto border-bottom border-primary border-">
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
       <!-- name -->
       <div class="my-3">

--- a/app/views/movies/shared/_nav.html.erb
+++ b/app/views/movies/shared/_nav.html.erb
@@ -1,0 +1,102 @@
+<nav class="navbar px-2 navbar-expand-sm p-0 navbar-light justify-content-sm-around bg-cerulean
+            text-white">
+  <a class="navbar-brand  m-sm-0" href="<%= root_path %>">
+    <%= image_tag 'logo_modified.png', width:"50", height: "30" %>
+    <span>Ruby Theater</span>
+  </a>
+  <button type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#navbarNav"
+          class="navbar-toggler collapsed d-flex d-sm-none flex-column justify-content-around m-0"
+          aria-controls="collapse"
+          aria-expanded="false"
+          aria-label="Toggle navigation">
+    <span class="toggler-icon top-bar"></span>
+    <span class="toggler-icon middle-bar"></span>
+    <span class="toggler-icon bottom-bar"></span>
+  </button>
+  <div class="collapse navbar-collapse flex-grow-0" id="navbarNav">
+    <ul class="navbar-nav active">
+      <li class="nav-item active">
+        <a href="#" class="nav-link text-white p-3">影城介紹</a>
+      </li>
+      <li class="nav-item active">
+        <a href="#" class="nav-link text-white p-3">電影介紹</a>
+      </li>
+      <% if user_signed_in? %>
+        <li class="nav-item active dropdown">
+          <a href="#" class="nav-link text-white p-3 dropdown-toggle"
+              data-bs-toggle="dropdown" aria-expanded="false">會員專區</a>
+          <ul class="dropdown-menu m-0 p-0">
+            <li><%= link_to "個人資料", edit_user_registration_path(current_user.id),
+                    class:"dropdown-item text-white p-3" %></li>
+            <li><%= link_to "訂票查詢", orders_path,
+              class:"dropdown-item text-white p-3" %></li>
+            <% if current_user.admin? || current_user.staff?%>
+              <li><%= link_to "影城管理", admin_movies_path,class:"dropdown-item text-white p-3" %></li>
+            <% end %>
+            <% if current_user.admin? %>
+              <li><%= link_to "後台管理", admin_users_path,class:"dropdown-item text-white p-3" %></li>
+            <% end %>
+          </ul>
+        </li>
+        <li class="nav-item active">
+          <%= link_to "登出", destroy_user_session_path,method: "delete",class: "nav-link text-white p-3" %>
+        </li>
+      <% else %>
+        <li class="nav-item active">
+          <button class="nav-link text-white p-3" data-bs-toggle="modal" data-bs-target="#Modal">
+            登入
+          </button>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</nav>
+<div class="modal fade" id="Modal" tabindex="-1" aria-labelledby="ModalLabel" aria-hidden="true"
+     data-controller="index-login" data-action="click->index-login#Modal">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header position-relative">
+        <h1 class="modal-title fs-5 col-12 text-center">Ruby Cinema</h1>
+        <button type="button" class="position-absolute translate-middle rounded-circle d-flex justify-content-center align-items-center "data-bs-dismiss="modal" data-action="click->index-login#clearInput">
+          <span class="position-absolute"></span>
+          <span class="position-absolute"></span>
+        </button>
+      </div>
+      <%= form_for @user, url: user_session_path, method:"post" do |f| %>
+        <div class="modal-body">
+          <div class="field mt-5 position-relative d-flex">
+            <%= f.email_field :email, autocomplete: "email", class:"form-control",
+                data:{ action: "click->index-login#addClassAt focusout->index-login#removeClassAt
+                            keyup->index-login#test", index_login_target: "email"}%>
+            <%= f.label :email, class:"form-inline position-absolute", data:{ index_login_target: "emailLabel" }%>
+          </div>
+          <div class="field mt-5 mb-3 position-relative d-flex">
+            <%= f.password_field :password, autocomplete: "current-password" ,class:"form-control",
+                data:{ action: "click->index-login#addClassAt focusout->index-login#removeClassAt
+                            keyup->index-login#test",index_login_target: "password"}%>
+            <%= f.label :password ,class:"form-inline position-absolute ",
+                data:{ index_login_target: "passwordLabel" }%>
+          </div>
+          <div class="forgot-password d-flex flex-row-reverse text-dodgerblue">
+            <%= link_to "Forgot your password?", new_user_password_path %>
+          </div>
+        </div>
+        <div class="modal-footer flex-column justify-content-center">
+          <div class="actions text-white">
+            <%= f.submit "登入" , class:"px-5 py-3 rounded-3", disabled: "disabled", data:{ index_login_target: "login" }%>
+          </div>
+          <div>
+            <%= link_to "<i class=\"fa-brands fa-facebook text-primary \"></i> Facebook登入".html_safe, user_facebook_omniauth_authorize_path, method: :post, class: "btn btn-outline-dark" %>
+            <%= link_to "<i class=\"fa-brands fa-google\"></i> Google登入".html_safe, user_google_oauth2_omniauth_authorize_path, method: :post, class: "btn btn-outline-dark" %>
+          </div>
+          <div class="sing-up">
+            <span>Don't have an account?</span>
+            <span class="ms-2"><%= link_to "註冊", new_user_registration_path %></span>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
1.後台使用者列表
<img width="1103" alt="截圖 2022-12-27 上午10 46 15" src="https://user-images.githubusercontent.com/116936412/209603082-3419ef79-d38d-4cfa-a92a-3bf2b7febaa0.png">

2.後台修改使用者資料
<img width="760" alt="截圖 2022-12-27 上午10 46 50" src="https://user-images.githubusercontent.com/116936412/209603124-a1ca30f4-5e23-4c29-8390-2c6160601651.png">

3.前台使用者變更會員資料
<img width="610" alt="截圖 2022-12-27 上午10 47 35" src="https://user-images.githubusercontent.com/116936412/209603200-6c62e2c9-c374-40bc-a572-2335e20bce6f.png">

sidebar跟nav列在禎緯的PR裡